### PR TITLE
hide colpick before removing from the DOM

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -489,6 +489,7 @@
                 });
             },
             destroy: function () {
+                hide.apply(this);
                 $('#' + $(this).data('colpickId')).remove();
             }
         };

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -83,6 +83,9 @@
         //Called when the new color is changed
             change = function () {
                 var cal = $(this).parent().parent(), col;
+
+                if (!cal.data('colpick')) { return; }
+
                 if (this.parentNode.className.indexOf('_hex') > 0) {
                     cal.data('colpick').color = col = hexToHsb(fixHex(this.value));
                     fillRGBFields(col, cal.get(0));
@@ -153,6 +156,7 @@
                     cal: $(this).parent(),
                     y: $(this).offset().top
                 };
+                if (!current.cal.data('colpick')) { return false; }
                 $(document).on('mouseup touchend', current, upHue);
                 $(document).on('mousemove touchmove', current, moveHue);
 
@@ -166,6 +170,8 @@
                 return false;
             },
             moveHue = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 var pageY = ((ev.type == 'touchmove') ? ev.originalEvent.changedTouches[0].pageY : ev.pageY );
                 change.apply(
                     ev.data.cal.data('colpick')
@@ -176,6 +182,8 @@
                 return false;
             },
             upHue = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend', upHue);
@@ -189,6 +197,7 @@
                     cal: $(this).parent(),
                     pos: $(this).offset()
                 };
+                if (!current.cal.data('colpick')) { return false; }
                 current.preview = current.cal.data('colpick').livePreview;
 
                 $(document).on('mouseup touchend', current, upSelector);
@@ -213,6 +222,8 @@
                 return false;
             },
             moveSelector = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 var pageX, pageY;
                 if (ev.type == 'touchmove') {
                     pageX = ev.originalEvent.changedTouches[0].pageX;
@@ -232,6 +243,8 @@
                 return false;
             },
             upSelector = function (ev) {
+                if (!ev.data.cal.data('colpick')) { return false; }
+
                 fillRGBFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 fillHexFields(ev.data.cal.data('colpick').color, ev.data.cal.get(0));
                 $(document).off('mouseup touchend', upSelector);


### PR DESCRIPTION
Hide colpick before removing it from the DOM
Fixes issues where the element is removed from the DOM without unbinding the mousedown event [`$('html').off('mousedown', hide)`]