### PR TITLE
Fixed logic error and correctly position the colorpicker menu on mobile displays

### DIFF
--- a/js/colpick.js
+++ b/js/colpick.js
@@ -269,6 +269,8 @@
                 cal.css({left: left + 'px', top: top + 'px'});
                 if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
                     cal.show();
+                    // Hide the keyboard on mobile devices by deselecting the text box
+                    $(document.activeElement).filter(':input:focus').blur();
                 }
                 //Hide when user clicks outside
                 $('html').mousedown({cal: cal}, hide);

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -262,8 +262,9 @@
                 var left = pos.left;
                 var viewPort = getViewport();
                 var calW = cal.width();
-                if (left + calW > viewPort.l + viewPort.w) {
-                    left -= calW;
+                var right = left + calW;
+                if (right > viewPort.w) {
+                    left = (viewPort.w-calW) / 2;
                 }
                 cal.css({left: left + 'px', top: top + 'px'});
                 if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -262,14 +262,19 @@
                 var left = pos.left;
                 var viewPort = getViewport();
                 var calW = cal.width();
+                var calH = cal.height();
+                var bottom = top + calH;
                 var right = left + calW;
                 if (right > viewPort.w) {
                     left = (viewPort.w-calW) / 2;
                 }
+                if (bottom > viewPort.l) {
+                    top -= (calH + this.offsetHeight);
+                }
                 cal.css({left: left + 'px', top: top + 'px'});
                 if (cal.data('colpick').onShow.apply(this, [cal.get(0)]) != false) {
                     cal.show();
-                    // Hide the keyboard on mobile devices by deselecting the text box
+                    // Hide the keyboard on mobile devices be deselecting the text box
                     $(document.activeElement).filter(':input:focus').blur();
                 }
                 //Hide when user clicks outside

--- a/js/colpick.js
+++ b/js/colpick.js
@@ -288,7 +288,7 @@
             getViewport = function () {
                 var m = document.compatMode == 'CSS1Compat';
                 return {
-                    l: window.pageXOffset || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
+                    l: window.innerHeight || (m ? document.documentElement.scrollLeft : document.body.scrollLeft),
                     w: window.innerWidth || (m ? document.documentElement.clientWidth : document.body.clientWidth)
                 };
             },


### PR DESCRIPTION
Picker menu will now center horizontally and/or snap to the top or bottom of the clicked element as needed.
The picker will also [attempt to] prevent launching the OS keyboard on mobile devices.